### PR TITLE
relaxe dateutil requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 django-jsonfield>=1.0.0
-python-dateutil==2.6.0
+python-dateutil>=2.6.0,<2.8

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,11 @@
 from distutils.core import setup
 
+
 setup(
     name='django-auditlog',
     version='0.4.7',
-    packages=['auditlog', 'auditlog.migrations', 'auditlog.management', 'auditlog.management.commands'],
+    packages=['auditlog', 'auditlog.migrations', 'auditlog.management',
+              'auditlog.management.commands'],
     package_dir={'': 'src'},
     url='https://github.com/jjkester/django-auditlog',
     license='MIT',
@@ -11,7 +13,7 @@ setup(
     description='Audit log app for Django',
     install_requires=[
         'django-jsonfield>=1.0.0',
-        'python-dateutil==2.6.0'
+        'python-dateutil>=2.6.0,<2.8'
     ],
     zip_safe=False,
     classifiers=[
@@ -23,5 +25,5 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'License :: OSI Approved :: MIT License',
-    ],        
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from distutils.core import setup
 
 setup(
     name='django-auditlog',
-    version='0.4.7',
+    version='0.4.8',
     packages=['auditlog', 'auditlog.migrations', 'auditlog.management',
               'auditlog.management.commands'],
     package_dir={'': 'src'},


### PR DESCRIPTION
Package maintainer fixed the version and is not responsive to request:
https://github.com/jjkester/django-auditlog/issues/205

django-scim2 requires python-dateutil to be at least 2.7.3 .. others might follow since 2.6.0 is already quite old.